### PR TITLE
Ignore SLF4J and JDWP messages

### DIFF
--- a/lsp-java.el
+++ b/lsp-java.el
@@ -81,7 +81,9 @@ The entry point of the language server is in `lsp-java-server-install-dir'/plugi
 
 (lsp-define-stdio-client 'java-mode "java" 'stdio #'lsp-java--get-root
 			 "Java Language Server"
-			 (lsp-java--ls-command))
+			 (lsp-java--ls-command)
+			 :ignore-regexps '("^SLF4J: "
+					   "^Listening for transport dt_socket at address: "))
 
 (provide 'lsp-java)
 ;;; lsp-java.el ends here


### PR DESCRIPTION
I can't get the backend started without these regexps:

Output in *Language Server STDERR*:

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

Also Output JDWP:

```
Listening for transport dt_socket at address: 1044
```

which results in this *elisp* backtrace:

```
Debugger entered--Lisp error: (error "Error parsing language server output: (wrong-type-argument stringp nil)")
  signal(error ("Error parsing language server output: (wrong-type-argument stringp nil)"))
  error("Error parsing language server output: %s" (wrong-type-argument stringp nil))
  (progn (lsp--parser-reset p) (progn (progn nil (or (progn nil (and (vectorp p) (>= (length p) 15) (memq (aref p 0) cl-struct-lsp--parser-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--parser) p))) (let* ((v p)) (aset v 2 nil))) (progn nil (or (progn nil (and (vectorp p) (>= (length p) 15) (memq (aref p 0) cl-struct-lsp--parser-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--parser) p))) (let* ((v p)) (aset v 1 nil)))) (error "Error parsing language server output: %s" err))
  (condition-case err (lsp--parser-read p output) (error (progn (lsp--parser-reset p) (progn (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... p))) (let* ((v p)) (aset v 2 nil))) (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... p))) (let* ((v p)) (aset v 1 nil)))) (error "Error parsing language server output: %s" err))))
  (progn (condition-case err (lsp--parser-read p output) (error (progn (lsp--parser-reset p) (progn (progn nil (or (progn nil ...) (signal ... ...)) (let* (...) (aset v 2 nil))) (progn nil (or (progn nil ...) (signal ... ...)) (let* (...) (aset v 1 nil)))) (error "Error parsing language server output: %s" err)))))
  (if (let* ((--cl-var-- ignore-regexps) (r nil) (--cl-var-- t) --cl-var--) (while (and (consp --cl-var--) (progn (setq r (car --cl-var--)) (if (string-match r output) (setq --cl-var-- nil --cl-var-- nil) t))) (setq --cl-var-- (cdr --cl-var--))) (if --cl-var-- (progn t) --cl-var--)) (progn (condition-case err (lsp--parser-read p output) (error (progn (lsp--parser-reset p) (progn (progn nil (or ... ...) (let* ... ...)) (progn nil (or ... ...) (let* ... ...))) (error "Error parsing language server output: %s" err))))))
  (closure ((ignore-regexps) (p . [cl-struct-lsp--parser nil nil nil "" nil nil nil nil nil nil nil [cl-struct-lsp--workspace #3 "java" 1 #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ( ...)) nil "/home/juergen/java/pushover4j/src/main/java/net/pushover/client/" [cl-struct-lsp--client "java" lsp--stdio-send-sync lsp--stdio-send-async stdio (closure (... ... t) (filter sentinel) (let ... ... ...)) lsp-java--get-root nil #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ( ...))] nil #<process Java Language Server> #<process Java Language Server> nil nil] #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ( ...)) #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ("workspace/applyEdit" lsp--workspace-apply-edit-handler ...))]) cl-struct-lsp--parser-tags t) (proc output) (setq lsp--no-response nil) (if (let* ((--cl-var-- ignore-regexps) (r nil) (--cl-var-- t) --cl-var--) (while (and (consp --cl-var--) (progn (setq r (car --cl-var--)) (if (string-match r output) (setq --cl-var-- nil --cl-var-- nil) t))) (setq --cl-var-- (cdr --cl-var--))) (if --cl-var-- (progn t) --cl-var--)) (progn (condition-case err (lsp--parser-read p output) (error (progn (lsp--parser-reset p) (progn (progn nil ... ...) (progn nil ... ...)) (error "Error parsing language server output: %s" err)))))) (if (progn nil (or (progn nil (and (vectorp p) (>= (length p) 15) (memq (aref p 0) cl-struct-lsp--parser-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--parser) p))) (aref p 1)) (progn (condition-case nil (let ((inhibit-quit nil)) (accept-process-output proc)) (quit (setq quit-flag t) (eval (quote (ignore nil))))))))(#<process Java Language Server> "Content-Length: 122
\n
\n{\"jsonrpc\":\"2.0\",\"method\":\"window/logMessage\",\"params\":{\"type\":3,\"message\":\"06.05.2017 09:49:52 \\u003e\\u003e initialize\"}}")
  accept-process-output(#<process Java Language Server>)
  (let ((inhibit-quit nil)) (accept-process-output proc))
  (condition-case nil (let ((inhibit-quit nil)) (accept-process-output proc)) (quit (setq quit-flag t) (eval (quote (ignore nil)))))
  (progn (condition-case nil (let ((inhibit-quit nil)) (accept-process-output proc)) (quit (setq quit-flag t) (eval (quote (ignore nil))))))
  (if (progn nil (or (progn nil (and (vectorp p) (>= (length p) 15) (memq (aref p 0) cl-struct-lsp--parser-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--parser) p))) (aref p 1)) (progn (condition-case nil (let ((inhibit-quit nil)) (accept-process-output proc)) (quit (setq quit-flag t) (eval (quote (ignore nil)))))))
  (closure ((ignore-regexps) (p . [cl-struct-lsp--parser nil nil nil "" nil nil nil nil nil nil nil [cl-struct-lsp--workspace #3 "java" 1 #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ( ...)) nil "/home/juergen/java/pushover4j/src/main/java/net/pushover/client/" [cl-struct-lsp--client "java" lsp--stdio-send-sync lsp--stdio-send-async stdio (closure (... ... t) (filter sentinel) (let ... ... ...)) lsp-java--get-root nil #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ( ...))] nil #<process Java Language Server> #<process Java Language Server> nil nil] #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ( ...)) #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ("workspace/applyEdit" lsp--workspace-apply-edit-handler ...))]) cl-struct-lsp--parser-tags t) (proc output) (setq lsp--no-response nil) (if (let* ((--cl-var-- ignore-regexps) (r nil) (--cl-var-- t) --cl-var--) (while (and (consp --cl-var--) (progn (setq r (car --cl-var--)) (if (string-match r output) (setq --cl-var-- nil --cl-var-- nil) t))) (setq --cl-var-- (cdr --cl-var--))) (if --cl-var-- (progn t) --cl-var--)) (progn (condition-case err (lsp--parser-read p output) (error (progn (lsp--parser-reset p) (progn (progn nil ... ...) (progn nil ... ...)) (error "Error parsing language server output: %s" err)))))) (if (progn nil (or (progn nil (and (vectorp p) (>= (length p) 15) (memq (aref p 0) cl-struct-lsp--parser-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--parser) p))) (aref p 1)) (progn (condition-case nil (let ((inhibit-quit nil)) (accept-process-output proc)) (quit (setq quit-flag t) (eval (quote (ignore nil))))))))(#<process Java Language Server> "Listening for transport dt_socket at address: 1044\n")
  accept-process-output(#<process Java Language Server> 10)
  (let ((inhibit-quit nil)) (accept-process-output proc lsp-response-timeout))
  (condition-case nil (let ((inhibit-quit nil)) (accept-process-output proc lsp-response-timeout)) (quit (setq quit-flag t) (eval (quote (ignore nil)))))
  lsp--stdio-send-sync("Content-Length: 352
\n
\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"initialize\",\n  \"params\": {\n    \"processId\": 15200,\n    \"rootPath\": \"/home/juergen/java/pushover4j/src/main/java/net/pushover/client/\",\n    \"capabilities\": {\n      \"workspace\": {\n        \"executeCommand\": {\n          \"dynamicRegistration\": true\n        }\n      },\n      \"textDocument\": {\n      }\n    }\n  },\n  \"id\": 1\n}" #<process Java Language Server>)
  funcall(lsp--stdio-send-sync "Content-Length: 352
\n
\n{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"initialize\",\n  \"params\": {\n    \"processId\": 15200,\n    \"rootPath\": \"/home/juergen/java/pushover4j/src/main/java/net/pushover/client/\",\n    \"capabilities\": {\n      \"workspace\": {\n        \"executeCommand\": {\n          \"dynamicRegistration\": true\n        }\n      },\n      \"textDocument\": {\n      }\n    }\n  },\n  \"id\": 1\n}" #<process Java Language Server>)
  (let* ((client (progn nil (or (progn nil (and (vectorp lsp--cur-workspace) (>= ... 13) (memq ... cl-struct-lsp--workspace-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--workspace) lsp--cur-workspace))) (aref lsp--cur-workspace 7))) (parser (lsp--cur-parser)) (send-func (if no-wait (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... client))) (aref client 3)) (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... client))) (aref client 2))))) (progn nil (or (progn nil (and (vectorp parser) (>= (length parser) 15) (memq (aref parser 0) cl-struct-lsp--parser-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--parser) parser))) (let* ((v parser)) (aset v 1 (not no-wait)))) (funcall send-func (lsp--make-message body) (progn nil (or (progn nil (and (vectorp lsp--cur-workspace) (>= (length lsp--cur-workspace) 13) (memq (aref lsp--cur-workspace 0) cl-struct-lsp--workspace-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--workspace) lsp--cur-workspace))) (aref lsp--cur-workspace 9))) (if (not no-wait) (progn (prog1 (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... parser))) (aref parser 2)) (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... parser))) (let* ((v parser)) (aset v 2 nil)))))))
  lsp--send-request((:jsonrpc "2.0" :method "initialize" :params (:processId 15200 :rootPath "/home/juergen/java/pushover4j/src/main/java/net/pushover/client/" :capabilities (:workspace (:executeCommand (:dynamicRegistration t)) :textDocument #s(hash-table size 65 test eql rehash-size 1.5 rehash-threshold 0.8 data ( ...)))) :id 1))
  (setq response (lsp--send-request (lsp--make-request "initialize" init-params)))
  (if workspace (setq lsp--cur-workspace workspace) (progn (setq parser (make-lsp--parser :method-handlers (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... client))) (aref client 8)) :request-handlers (lsp--client-request-handlers))) (setq lsp--cur-workspace (make-lsp--workspace :parser parser :language-id (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... client))) (aref client 1)) :file-versions (make-hash-table :test (quote equal)) :last-id 0 :root root :client client)) (progn nil (or (progn nil (and (vectorp parser) (>= (length parser) 15) (memq (aref parser 0) cl-struct-lsp--parser-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--parser) parser))) (let* ((v parser)) (aset v 12 lsp--cur-workspace))) (setq new-conn (funcall (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... client))) (aref client 5)) (lsp--parser-make-filter parser (progn nil (or (progn nil ...) (signal ... ...)) (aref client 7))) (lsp--make-sentinel (current-buffer)))) (setq cmd-proc (if (consp new-conn) (car new-conn) new-conn)) (setq proc (if (consp new-conn) (cdr new-conn) new-conn)) (progn nil (or (progn nil (and (vectorp lsp--cur-workspace) (>= (length lsp--cur-workspace) 13) (memq (aref lsp--cur-workspace 0) cl-struct-lsp--workspace-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--workspace) lsp--cur-workspace))) (let* ((v lsp--cur-workspace)) (aset v 9 proc))) (progn nil (or (progn nil (and (vectorp lsp--cur-workspace) (>= (length lsp--cur-workspace) 13) (memq (aref lsp--cur-workspace 0) cl-struct-lsp--workspace-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--workspace) lsp--cur-workspace))) (let* ((v lsp--cur-workspace)) (aset v 10 cmd-proc))) (setq init-params (list (quote :processId) (emacs-pid) (quote :rootPath) root (quote :capabilities) (lsp--client-capabilities)))) (puthash root lsp--cur-workspace lsp--workspaces) (setq response (lsp--send-request (lsp--make-request "initialize" init-params))) (if response nil (signal (quote lsp-empty-response-error) "initialize")) (progn nil (or (progn nil (and (vectorp lsp--cur-workspace) (>= (length lsp--cur-workspace) 13) (memq (aref lsp--cur-workspace 0) cl-struct-lsp--workspace-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--workspace) lsp--cur-workspace))) (let* ((v lsp--cur-workspace)) (aset v 5 (gethash "capabilities" response)))) (lsp--send-notification (lsp--make-notification "initialized" nil)) (run-hooks lsp-after-initialize-hook))
  (if should-not-init (message "Not initializing project %s" root) (if workspace (setq lsp--cur-workspace workspace) (progn (setq parser (make-lsp--parser :method-handlers (progn nil (or (progn nil ...) (signal ... ...)) (aref client 8)) :request-handlers (lsp--client-request-handlers))) (setq lsp--cur-workspace (make-lsp--workspace :parser parser :language-id (progn nil (or (progn nil ...) (signal ... ...)) (aref client 1)) :file-versions (make-hash-table :test (quote equal)) :last-id 0 :root root :client client)) (progn nil (or (progn nil (and (vectorp parser) (>= ... 15) (memq ... cl-struct-lsp--parser-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--parser) parser))) (let* ((v parser)) (aset v 12 lsp--cur-workspace))) (setq new-conn (funcall (progn nil (or (progn nil ...) (signal ... ...)) (aref client 5)) (lsp--parser-make-filter parser (progn nil (or ... ...) (aref client 7))) (lsp--make-sentinel (current-buffer)))) (setq cmd-proc (if (consp new-conn) (car new-conn) new-conn)) (setq proc (if (consp new-conn) (cdr new-conn) new-conn)) (progn nil (or (progn nil (and (vectorp lsp--cur-workspace) (>= ... 13) (memq ... cl-struct-lsp--workspace-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--workspace) lsp--cur-workspace))) (let* ((v lsp--cur-workspace)) (aset v 9 proc))) (progn nil (or (progn nil (and (vectorp lsp--cur-workspace) (>= ... 13) (memq ... cl-struct-lsp--workspace-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--workspace) lsp--cur-workspace))) (let* ((v lsp--cur-workspace)) (aset v 10 cmd-proc))) (setq init-params (list (quote :processId) (emacs-pid) (quote :rootPath) root (quote :capabilities) (lsp--client-capabilities)))) (puthash root lsp--cur-workspace lsp--workspaces) (setq response (lsp--send-request (lsp--make-request "initialize" init-params))) (if response nil (signal (quote lsp-empty-response-error) "initialize")) (progn nil (or (progn nil (and (vectorp lsp--cur-workspace) (>= (length lsp--cur-workspace) 13) (memq (aref lsp--cur-workspace 0) cl-struct-lsp--workspace-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--workspace) lsp--cur-workspace))) (let* ((v lsp--cur-workspace)) (aset v 5 (gethash "capabilities" response)))) (lsp--send-notification (lsp--make-notification "initialized" nil)) (run-hooks lsp-after-initialize-hook)) (lsp--text-document-did-open))
  (let* ((client (lsp--get-client t)) (root (funcall (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... client))) (aref client 6)))) (workspace (gethash root lsp--workspaces)) (should-not-init (member root lsp-project-blacklist)) conn response init-params) (if should-not-init (message "Not initializing project %s" root) (if workspace (setq lsp--cur-workspace workspace) (progn (setq parser (make-lsp--parser :method-handlers (progn nil (or ... ...) (aref client 8)) :request-handlers (lsp--client-request-handlers))) (setq lsp--cur-workspace (make-lsp--workspace :parser parser :language-id (progn nil (or ... ...) (aref client 1)) :file-versions (make-hash-table :test (quote equal)) :last-id 0 :root root :client client)) (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... parser))) (let* ((v parser)) (aset v 12 lsp--cur-workspace))) (setq new-conn (funcall (progn nil (or ... ...) (aref client 5)) (lsp--parser-make-filter parser (progn nil ... ...)) (lsp--make-sentinel (current-buffer)))) (setq cmd-proc (if (consp new-conn) (car new-conn) new-conn)) (setq proc (if (consp new-conn) (cdr new-conn) new-conn)) (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... lsp--cur-workspace))) (let* ((v lsp--cur-workspace)) (aset v 9 proc))) (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... lsp--cur-workspace))) (let* ((v lsp--cur-workspace)) (aset v 10 cmd-proc))) (setq init-params (list (quote :processId) (emacs-pid) (quote :rootPath) root (quote :capabilities) (lsp--client-capabilities)))) (puthash root lsp--cur-workspace lsp--workspaces) (setq response (lsp--send-request (lsp--make-request "initialize" init-params))) (if response nil (signal (quote lsp-empty-response-error) "initialize")) (progn nil (or (progn nil (and (vectorp lsp--cur-workspace) (>= ... 13) (memq ... cl-struct-lsp--workspace-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--workspace) lsp--cur-workspace))) (let* ((v lsp--cur-workspace)) (aset v 5 (gethash "capabilities" response)))) (lsp--send-notification (lsp--make-notification "initialized" nil)) (run-hooks lsp-after-initialize-hook)) (lsp--text-document-did-open)))
  lsp--start()
  (let ((last-message (current-message))) (setq lsp-mode (if (eq arg (quote toggle)) (not lsp-mode) (> (prefix-numeric-value arg) 0))) (lsp--start) (run-hooks (quote lsp-mode-hook) (if lsp-mode (quote lsp-mode-on-hook) (quote lsp-mode-off-hook))) (if (called-interactively-p (quote any)) (progn nil (if (and (current-message) (not (equal last-message (current-message)))) nil (let ((local " in current buffer")) (message "Lsp mode %sabled%s" (if lsp-mode "en" "dis") local))))))
  lsp-mode(toggle)
  funcall-interactively(lsp-mode toggle)
```
