### PR TITLE
Utilize projectile and vc to get project root

### DIFF
--- a/lsp-java.el
+++ b/lsp-java.el
@@ -79,7 +79,9 @@ The current directory is assumed to be the java project’s root otherwise."
   (cond
    ((and (featurep 'projectile) (projectile-project-p)) (projectile-project-root))
    ((vc-backend default-directory) (expand-file-name (vc-root-dir)))
-   (t default-directory)))
+   (t (let ((project-types '("pom.xml" "build.gradle" ".project")))
+	(or (seq-some (lambda (file) (locate-dominating-file default-directory file)) project-types)
+	    default-directory)))))
 
 (lsp-define-stdio-client 'java-mode "java" 'stdio #'lsp-java--get-root
 			 "Java Language Server"

--- a/lsp-java.el
+++ b/lsp-java.el
@@ -73,11 +73,13 @@ The entry point of the language server is in `lsp-java-server-install-dir'/plugi
        ,root-dir)))
 
 (defun lsp-java--get-root ()
-  "TODO: use projectile directory"
-  (let ((dir default-directory))
-    (if (string= dir "/")
-        (user-error (concat "Couldn't find java root, using:" dir))
-      dir)))
+  "Retrieves the root directory of the java project root if available.
+
+The current directory is assumed to be the java project’s root otherwise."
+  (cond
+   ((and (featurep 'projectile) (projectile-project-p)) (projectile-project-root))
+   ((vc-backend default-directory) (expand-file-name (vc-root-dir)))
+   (t default-directory)))
 
 (lsp-define-stdio-client 'java-mode "java" 'stdio #'lsp-java--get-root
 			 "Java Language Server"


### PR DESCRIPTION
As suggested in the *DOCSTRING* . Without a sane project root *LSP4J* is limited to syntax-errors:
```
Output from language server: {"jsonrpc":"2.0","method":"language/actionableNotification","params":{"severity":2,"message":"Classpath is incomplete. Only syntax errors will be reported","commands":[{"title":"More Information","command":"java.ignoreIncompleteClasspath.help"},{"title":"Don\u0027t Show Again","command":"java.ignoreIncompleteClasspath"}]}}
```