### PR TITLE
Format enabled/Optimize imports options

### DIFF
--- a/lsp-java.el
+++ b/lsp-java.el
@@ -207,14 +207,14 @@ A package or type name prefix (e.g. 'org.eclipse') is a valid entry. An import i
      (implementationsCodeLens
       (enabled . t))
      (format
-      (enabled . ,(lsp-java-json-bool lsp-java-format-enabled))
+      (enabled . ,(lsp-java--json-bool lsp-java-format-enabled))
       (settings
        (profile . ,lsp-java-format-settings-profile)
        (url . ,lsp-java-format-settings-url))
       (comments
-       (enabled . ,(lsp-java-json-bool lsp-java-format-comments-enabled))))
+       (enabled . ,(lsp-java--json-bool lsp-java-format-comments-enabled))))
      (saveActions
-      (organizeImports . ,(lsp-java-json-bool lsp-java-format-enabled)))
+      (organizeImports . ,(lsp-java--json-bool lsp-java-format-enabled)))
      (contentProvider)
      (autobuild
       (enabled . t))

--- a/lsp-java.el
+++ b/lsp-java.el
@@ -145,6 +145,12 @@ A package or type name prefix (e.g. 'org.eclipse') is a valid entry. An import i
   :type 'boolean)
 
 ;;;###autoload
+(defcustom lsp-java-format-enabled 't
+  "Specifies whether or not formatting is enabled on the language server."
+  :group 'lsp-java
+  :type 'boolean)
+
+;;;###autoload
 (defcustom lsp-java-format-settings-url nil
   "Specifies the file path to the formatter xml url."
   :group 'lsp-java
@@ -191,7 +197,7 @@ A package or type name prefix (e.g. 'org.eclipse') is a valid entry. An import i
      (implementationsCodeLens
       (enabled . t))
      (format
-      (enabled . t)
+      (enabled . ,lsp-java-format-enabled)
       (settings
        (profile . ,lsp-java-format-settings-profile)
        (url . ,lsp-java-format-settings-url))

--- a/lsp-java.el
+++ b/lsp-java.el
@@ -145,7 +145,7 @@ A package or type name prefix (e.g. 'org.eclipse') is a valid entry. An import i
   :type 'boolean)
 
 ;;;###autoload
-(defcustom lsp-java-format-enabled 't
+(defcustom lsp-java-format-enabled t
   "Specifies whether or not formatting is enabled on the language server."
   :group 'lsp-java
   :type 'boolean)
@@ -174,7 +174,7 @@ A package or type name prefix (e.g. 'org.eclipse') is a valid entry. An import i
   :group 'lsp-java
   :type 'boolean)
 
-(defun lsp-java-json-bool (param)
+(defun lsp-java--json-bool (param)
   "Return a param for setting parsable by json.el for booleans"
   (if param 't :json-false))
 

--- a/lsp-java.el
+++ b/lsp-java.el
@@ -168,6 +168,16 @@ A package or type name prefix (e.g. 'org.eclipse') is a valid entry. An import i
   :group 'lsp-java
   :type 'boolean)
 
+;;;###autoload
+(defcustom lsp-java-organize-imports 't
+  "Specifies whether or not organize imports is enabled as a save action."
+  :group 'lsp-java
+  :type 'boolean)
+
+(defun lsp-java-json-bool (param)
+  "Return a param for setting parsable by json.el for booleans"
+  (if param 't :json-false))
+
 (defun lsp-java--settings ()
   "JDT settings."
   `((java
@@ -197,14 +207,14 @@ A package or type name prefix (e.g. 'org.eclipse') is a valid entry. An import i
      (implementationsCodeLens
       (enabled . t))
      (format
-      (enabled . ,lsp-java-format-enabled)
+      (enabled . ,(lsp-java-json-bool lsp-java-format-enabled))
       (settings
        (profile . ,lsp-java-format-settings-profile)
        (url . ,lsp-java-format-settings-url))
       (comments
-       (enabled . ,lsp-java-format-comments-enabled)))
+       (enabled . ,(lsp-java-json-bool lsp-java-format-comments-enabled))))
      (saveActions
-      (organizeImports . t))
+      (organizeImports . ,(lsp-java-json-bool lsp-java-format-enabled)))
      (contentProvider)
      (autobuild
       (enabled . t))

--- a/lsp-java.el
+++ b/lsp-java.el
@@ -133,7 +133,7 @@ A package or type name prefix (e.g. 'org.eclipse') is a valid entry. An import i
 (defcustom lsp-java-trace-server 'off
   "Traces the communication between Emacs and the Java language server."
   :group 'lsp-java
-  :type '(choise
+  :type '(choice
           (const off)
           (const messages)
           (const verbose)))


### PR DESCRIPTION
I use google-java-format quite regularly as my formatter, and there are [issues](https://github.com/google/styleguide/issues/273) with this. Hence i would like to turn off formatting and organize imports on save for language server.

Also there was a typo on the `lsp-java-trace-server` type that I corrected `choise` -> `choice`.