### PR TITLE
fix: match gradle file names correctly

### DIFF
--- a/lsp-java.el
+++ b/lsp-java.el
@@ -302,7 +302,7 @@ FULL specify whether full or incremental build will be performed."
   (let ((file-name (file-name-nondirectory (buffer-file-name))))
     (if-let ((lsp--cur-workspace (or lsp--cur-workspace
                                      (gethash (lsp-java--get-root) lsp--workspaces))))
-        (if (or (string= file-name "pom.xml") (string-match file-name ".*\.gradle"))
+        (if (or (string= file-name "pom.xml") (string-match "\\.gradle\\'" file-name))
             (lsp-send-notification
              (lsp-make-request "java/projectConfigurationUpdate"
                                (list :uri (lsp--buffer-uri))))


### PR DESCRIPTION
This fixes an issue where gradle build files are not recognized correctly. I chose to use `string-suffix-p` here, but another potential fix would've been to just transpose the arguments to `string-match` (since the regex should go first).