### PR TITLE
Make lsp-java-workspace-cache-dir use workspace-dir by default

### DIFF
--- a/lsp-java.el
+++ b/lsp-java.el
@@ -65,7 +65,7 @@ The slash is expected at the end."
   :risky t
   :type 'directory)
 
-(defcustom lsp-java-workspace-cache-dir (expand-file-name (locate-user-emacs-file "workspace/.cache/"))
+(defcustom lsp-java-workspace-cache-dir (expand-file-name ".cache/" lsp-java-workspace-dir)
   "LSP java workspace cache directory."
   :group 'lsp-java
   :risky t


### PR DESCRIPTION
This makes it a tiny bit easier if you want to
customize the workspace path as you only have to set
1 instead of 2 variables.