### PR TITLE
detect & import gradle projects with kotlin build scripts

### DIFF
--- a/features/ImportProject.feature
+++ b/features/ImportProject.feature
@@ -7,3 +7,19 @@ Feature: Importing projects
     And I add project "m" folder "tmp" to the list of workspace folders
     And I start lsp-java
     Then The server status must become "LSP::Started"
+
+  Scenario: Gradle Groovy DSL projects
+    Given I have gradle groovy DSL project "m" in "tmp"
+    And I have a java file "tmp/m/src/main/java/temp/App.java"
+    And I clear the buffer
+    And I add project "m" folder "tmp" to the list of workspace folders
+    And I start lsp-java
+    Then The server status must become "LSP::Started"
+
+  Scenario: Gradle Kotlin DSL projects
+    Given I have gradle kotlin DSL project "m" in "tmp"
+    And I have a java file "tmp/m/src/main/java/temp/App.java"
+    And I clear the buffer
+    And I add project "m" folder "tmp" to the list of workspace folders
+    And I start lsp-java
+    Then The server status must become "LSP::Started"

--- a/features/step-definitions/lsp-java-steps.el
+++ b/features/step-definitions/lsp-java-steps.el
@@ -39,8 +39,7 @@
                      (setq retry-count (1+ retry-count))
                      (message "The function failed, attempt %s" retry-count)))))))
 
-(Given "^I have maven project \"\\([^\"]+\\)\" in \"\\([^\"]+\\)\"$"
-       (lambda (project-name dir-name)
+(defun lsp-java-steps-project (project-name dir-name config-name config)
          (setq default-directory lsp-java-test-root)
 
          ;; delete old directory
@@ -52,8 +51,12 @@
                  (f-join   dir-name project-name "src" "main" "java" "temp")) t)
 
          ;; add pom.xml
-         (with-temp-file (expand-file-name "pom.xml" (f-join dir-name project-name))
-           (insert "
+         (with-temp-file (expand-file-name config-name (f-join dir-name project-name))
+           (insert config)))
+
+(Given "^I have maven project \"\\([^\"]+\\)\" in \"\\([^\"]+\\)\"$"
+       (lambda (project-name dir-name)
+				 (lsp-java-steps-project project-name dir-name "pom.xml" "
 <project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
   xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">
   <modelVersion>4.0.0</modelVersion>
@@ -68,7 +71,33 @@
       <maven.compiler.source>1.8</maven.compiler.source>
       <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
-</project>"))))
+</project>")))
+
+(Given "^I have gradle groovy DSL project \"\\([^\"]+\\)\" in \"\\([^\"]+\\)\"$"
+       (lambda (project-name dir-name)
+				 (lsp-java-steps-project project-name dir-name "build.gradle" "
+plugins {
+    id 'java'
+}
+repositories {
+    jcenter()
+}
+dependencies {
+    implementation 'com.google.guava:guava:27.0.1-jre'
+}")))
+
+(Given "^I have gradle kotlin DSL project \"\\([^\"]+\\)\" in \"\\([^\"]+\\)\"$"
+       (lambda (project-name dir-name)
+				 (lsp-java-steps-project project-name dir-name "build.gradle.kts" "
+plugins {
+    java
+}
+repositories {
+    jcenter()
+}
+dependencies {
+    implementation(\"com.google.guava:guava:27.0.1-jre\")
+}")))
 
 (And "^I have a java file \"\\([^\"]+\\)\"$"
      (lambda (file-name)

--- a/lsp-java.el
+++ b/lsp-java.el
@@ -65,6 +65,11 @@ Use http://download.eclipse.org/che/che-ls-jdt/snapshots/che-jdt-language-server
   "face for activity message"
   :group 'lsp-java)
 
+(defcustom lsp-java-project-types '("pom.xml" "build.gradle" "build.gradle.kts" ".project")
+  "File names of possible project configuration files found at project root."
+  :group 'lsp-java
+  :type '(repeat file))
+
 (defcustom lsp-java-workspace-dir (expand-file-name (locate-user-emacs-file "workspace/"))
   "LSP java workspace directory."
   :group 'lsp-java
@@ -472,9 +477,8 @@ The current directory is assumed to be the java project’s root otherwise."
    ((string= default-directory lsp-java-workspace-cache-dir) default-directory)
    ((and (featurep 'projectile) (projectile-project-p)) (projectile-project-root))
    ((vc-backend default-directory) (expand-file-name (vc-root-dir)))
-   (t (let ((project-types '("pom.xml" "build.gradle" ".project")))
-        (or (seq-some (lambda (file) (locate-dominating-file default-directory file)) project-types)
-            default-directory)))))
+   (t (or (seq-some (lambda (file) (locate-dominating-file default-directory file)) lsp-java-project-types)
+          default-directory))))
 
 (defun lsp-java--language-status-callback (workspace params)
   "Callback for client initialized.
@@ -1122,7 +1126,7 @@ PROJECT-URI uri of the item."
                            ("registerOptions" (ht ("watchers"
                                                    (vector (ht ("globPattern" "**/*.java"))
                                                            (ht ("globPattern" "**/pom.xml"))
-                                                           (ht ("globPattern" "**/*.gradle"))
+                                                           (ht ("globPattern" "**/*.gradle{,.kts}"))
                                                            (ht ("globPattern" "**/.project"))
                                                            (ht ("globPattern" "**/.classpath"))
                                                            (ht ("globPattern" "**/settings/*.prefs"))))))))))


### PR DESCRIPTION
`lsp-java` wasn't importing gradle projects initialized to use [kotlin build scripts][kotlin].
As a result, `lsp` was indicating valid code as wrong, and it wasn't locating the project root/workspace.
This pull request fixes those issues for me.

I also exposed the list of possible project configuration files as a custom variable, since it might save users inconvenience when trying out new/experimental build tools.

Despite adding tests to cover these cases, however, the project's tests don't seem work at all, even on the continuous integration platform.
I'd recommend someone who's ever gotten `ecukes` to work (never has for me), to fix the tests.

Does this need further work?

[kotlin]: https://docs.gradle.org/current/userguide/kotlin_dsl.html#sec:scripts
