### PR TITLE
`maven.codenvycorp.com' no longer alive; installation hangs

### DIFF
--- a/install/pom.xml
+++ b/install/pom.xml
@@ -8,19 +8,6 @@
     <root.install.dir>${user.home}/.emacs.d/eclipse.jdt.ls</root.install.dir>
   </properties>
   <packaging>pom</packaging>
-  <repositories>
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>codenvy-public-repo</id>
-      <name>codenvy public</name>
-      <url>https://maven.codenvycorp.com/content/groups/public/</url>
-    </repository>
-  </repositories>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Installation hangs: as `maven.codenvycorp.com` no longer seems to be alive, Maven's attempts to fetch POMs from it will time out. However, all the POMs seem to be available on `central`, so I propose removing the repository from the list in `install/pom.xml` as a solution.