### PR TITLE
update pom.xml - bump junit standalone

### DIFF
--- a/install/pom.xml
+++ b/install/pom.xml
@@ -124,7 +124,7 @@
                 <artifactItem>
                   <groupId>org.junit.platform</groupId>
                   <artifactId>junit-platform-console-standalone</artifactId>
-                  <version>1.3.0-M1</version>
+                  <version>1.6.2</version>
                   <outputDirectory>${junit.runner.root}</outputDirectory>
                   <destFileName>${junit.runner.fileName}</destFileName>
                 </artifactItem>


### PR DESCRIPTION
The latest stable version of junit-platform-console-standalone appears to be 1.6.2. Previously it was on 1.3.0-M1, a milestone release. I was encountering some odd classpath issues with Junit5 until I used the newer version.