### PR TITLE
Support java.import.gradle.version and wrapper.enabled

### DIFF
--- a/lsp-java.el
+++ b/lsp-java.el
@@ -485,11 +485,10 @@ FULL specify whether full or incremental build will be performed."
 
    ;; otherwise, get the version from gradlew at the project root, if any
    ;; this is also a workaround for when gradle-wrapper.properties is not at its default location
-   (t (let* ((project-gradlew (concat (lsp-java--get-root) "gradlew -v"))
+   (t (let* ((project-gradlew (f-join (lsp-java--get-root) "gradlew -v"))
              (gradle-version-output (shell-command-to-string project-gradlew)))
-        (if (string-match "Revision" gradle-version-output)
-            (nth 2 (split-string gradle-version-output))
-          nil)))))
+        (when (string-match "Revision" gradle-version-output)
+            (nth 2 (split-string gradle-version-output)))))))
 
 (defun lsp-java--ls-command ()
   "LS startup command."


### PR DESCRIPTION
This adds support for java language server settings related to importing a gradle project:
```
java.import.gradle.version
java.import.gradle.wrapper.enabled
```
By default, gradle.wrapper.enabled is true, which tells the java language server to use the wrapper distribution for the project.

If the project doesn't use gradle wrapper, then a gradle version can be specified for the language server to use. This is done by setting:
```
java.import.gradle.wrapper.enabled: false
java.import.gradle.version: "6.4"
```
If the project uses gradle wrapper, but the wrapper properties is not at its defaul location, then the buildship can't read the wrapper distribution, resulting in using te buildship's gradle distribution. To specify the version of the project's gradle wrapper in such case, use the below settings:
```
java.import.gradle.wrapper.enabled: false
java.import.gradle.version: nil
```
With gradle.version `nil`, lsp-java will try to locate gradlew at the project root and run it to get the gradle version. This is a workaround for issue #221 and eclipse/eclipse.jdt.ls#1431