### PR TITLE
Add support for custom jvm arguments to be passed to gradle

### DIFF
--- a/lsp-java.el
+++ b/lsp-java.el
@@ -144,6 +144,10 @@ server."
   "Gradle version, used if the gradle wrapper is missing or disabled."
   :type 'string)
 
+(defcustom lsp-java-import-gradle-jvm-arguments nil
+  "JVM arguments to pass to Gradle."
+  :type '(repeat string))
+
 (defcustom lsp-java-import-gradle-wrapper-enabled t
   "Enable/disable using the Gradle wrapper distribution."
   :type 'boolean)
@@ -349,6 +353,7 @@ example 'java.awt.*' will hide all types from the awt packages."
    ("java.import.maven.enabled" lsp-java-import-maven-enabled t)
    ("java.import.gradle.enabled" lsp-java-import-gradle-enabled t)
    ("java.import.gradle.version" lsp-java--get-gradle-version)
+   ("java.import.gradle.jvmArguments" lsp-java-import-gradle-jvm-arguments)
    ("java.import.gradle.wrapper.enabled" lsp-java-import-gradle-wrapper-enabled t)
    ("java.trace.server" lsp-java-trace-server)
    ("java.configuration.updateBuildConfiguration" lsp-java-configuration-update-build-configuration)


### PR DESCRIPTION
Large projects may have issues with gradle running out of memory, and this
change allows them to allocate more memory to the gradle process by using
something like the following:

```lisp
(setq lsp-java-import-gradle-jvm-arguments ["-Xmx1G"])
```