### PR TITLE
Quick start conf work on clean Emacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,16 @@ Then add the following lines to your `.emacs` and open a file from the any of th
 ### Quick start
 Minimal configuration with [company-capf](https://github.com/company-mode/company-mode) and [lsp-ui](https://github.com/emacs-lsp/lsp-ui) and [dap-mode](https://github.com/yyoncho/dap-mode/). Now you can explore the methods under `lsp-java-*`, `dap-java-*`, `dap-*`, and `lsp-*`
 ```elisp
-(add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/"))
-
-(when (not (package-installed-p 'use-package))
-  (package-refresh-contents)
-  (package-install 'use-package))
+(condition-case nil
+    (require 'use-package)
+  (file-error
+   (require 'package)
+   (add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/"))
+   (package-initialize)
+   (package-refresh-contents)
+   (package-install 'use-package)
+   (setq use-package-always-ensure t)
+   (require 'use-package)))
 
 (use-package projectile)
 (use-package flycheck)


### PR DESCRIPTION
- the quick start is now self sufficient. A user can try out lsp-java
  just by copying and pasting the conf snippet and it will work
  without any other Emacs conf.

- fixes error:

      if: Symbol’s value as variable is void: package-archives

- fixes warnings about packages not being installed (in my case, this
  was which-key and helm-lsp), the 'use-package-always-ensure' removes
  the need for installing the packages prior to evaluating the quick
  start snippet.

- tested on Emacs 28.0.50