### PR TITLE
Minor fixes and clean up for `dap-java.el`

### DIFF
--- a/dap-java.el
+++ b/dap-java.el
@@ -245,12 +245,12 @@ test."
                            (s-join dap-java--classpath-separator)))
           (prog-list (if dap-java-use-testng
                          (cl-list* runner
-                                    "-cp" (format dap-java--var-format "JUNIT_CLASS_PATH")
-                                    "org.testng.TestNG"
-                                    "-d" dap-java-testng-report-dir
-                                    (if (and (s-contains? "#" to-run) run-method?) "-methods" "-testclass")
-                                    (if run-method? (s-replace "#" "." to-run) test-class-name)
-                                    dap-java-test-additional-args)
+                                   "-cp" (format dap-java--var-format "JUNIT_CLASS_PATH")
+                                   "org.testng.TestNG"
+                                   "-d" dap-java-testng-report-dir
+                                   (if (and (s-contains? "#" to-run) run-method?) "-methods" "-testclass")
+                                   (if run-method? (s-replace "#" "." to-run) test-class-name)
+                                   dap-java-test-additional-args)
                        (cl-list* runner "-jar" dap-java-test-runner
                                  "-cp" (format dap-java--var-format "JUNIT_CLASS_PATH")
                                  (if (and (s-contains? "#" to-run) run-method?) "-m" "-c")

--- a/dap-java.el
+++ b/dap-java.el
@@ -231,9 +231,8 @@ initiate `compile' and attach to the process."
 
 (defun dap-java--run-unit-test-command (runner run-method?)
   "Run debug test with the following arguments.
-RUNNER is the test executor. RUN-METHOD? when t it will try to
-run the surrounding method. Otherwise it will run the surronding
-test."
+RUNNER is the test executor.  RUN-METHOD? when t it will try to run the
+surrounding method.  Otherwise it will run the surronding test."
   (-let* ((to-run (if run-method?
                       (dap-java-test-method-at-point)
                     (dap-java-test-class)))

--- a/dap-java.el
+++ b/dap-java.el
@@ -144,6 +144,7 @@ Please check whether the server is configured propertly"))
                                         (lsp-get it :projectName)))
                               nil
                               t)))))
+
 (defun dap-java--populate-launch-args (conf)
   "Populate CONF with launch related configurations."
   (when (not (and (plist-get conf :mainClass)


### PR DESCRIPTION
This patch fixes the following for `dap-java.el`.

* Fixed the indention.
* Fixed package lint warnings.