### PR TITLE
Asks for the name of the method, If none found. No suggestions.

### DIFF
--- a/dap-java.el
+++ b/dap-java.el
@@ -121,7 +121,8 @@ If the port is taken, DAP will try the next port."
                                              (lsp-region-text selection-range)))))
                             children?))))
              (cl-first))
-        (user-error "No method at point"))))
+	(let ((method (read-string "no method at point. Name:")))
+	  (concat (dap-java-test-class) "#" method)))))
 
 (defun dap-java--select-main-class ()
   "Select main class from the current workspace."


### PR DESCRIPTION
Instead of throwing an user error if there is no method at point, ``dap-java-test-method-at-point`` asks for a method name.
It would be nice to use completing-read, with the methods names as suggestions.