### PR TITLE
Fix test report buffer update.

### DIFF
--- a/lsp-jt.el
+++ b/lsp-jt.el
@@ -617,7 +617,7 @@
                                                             (gethash test-id lsp-jt-results)
                                                             :traces))
                                            :icon none)))))))))
-   "Java Test Results" nil "*Java Tests Resuls*"))
+   "Java Test Results" nil "*Java Tests Results*"))
 (defun lsp-jt--report-buffer-hook ()
   (remove-hook 'lsp-jt-status-updated-hook #'lsp-jt--update-report))
 


### PR DESCRIPTION
Java test report buffer not being updated when tests are re-run. This is caused by a typo in the name of the buffer within lsp-jt-test-report-refresh.