### PR TITLE
Bump download-maven-plugin to 1.6.7

### DIFF
--- a/install/pom.xml
+++ b/install/pom.xml
@@ -13,7 +13,7 @@
       <plugin>
         <groupId>com.googlecode.maven-download-plugin</groupId>
         <artifactId>download-maven-plugin</artifactId>
-        <version>1.3.0</version>
+        <version>1.6.7</version>
         <executions>
           <execution>
             <phase>process-resources</phase>


### PR DESCRIPTION
Https proxy works after 1.5.1. See https://github.com/maven-download-plugin/maven-download-plugin/pull/157