### PR TITLE
Update default jdtls version from 1.12.0 -> 1.14.0

### DIFF
--- a/lsp-java.el
+++ b/lsp-java.el
@@ -47,7 +47,7 @@ The slash is expected at the end."
   :risky t
   :type 'directory)
 
-(defcustom lsp-java-jdt-download-url "https://download.eclipse.org/jdtls/milestones/1.12.0/jdt-language-server-1.12.0-202206011637.tar.gz"
+(defcustom lsp-java-jdt-download-url "https://download.eclipse.org/jdtls/milestones/1.14.0/jdt-language-server-1.14.0-202207211651.tar.gz"
   "JDT JS download url.
 Use http://download.eclipse.org/che/che-ls-jdt/snapshots/che-jdt-language-server-latest.tar.gz if you want to use Eclipse Che JDT LS."
   :group 'lsp-java


### PR DESCRIPTION
This PR updates the defaults value of `lsp-java-jdt-download-url` to point to the newest version of jdtls from [https://download.eclipse.org/jdtls/milestones](https://download.eclipse.org/jdtls/milestones)