### PR TITLE
feat: add support for `java-ts-mode`

### DIFF
--- a/lsp-java-boot.el
+++ b/lsp-java-boot.el
@@ -142,7 +142,7 @@ Store CALLBACK to use it `sts/highlight'."
                   (lsp-tcp-server #'lsp-java-boot--ls-command)
                   :activation-fn (lambda (_filename mode)
                                    (and lsp-java-boot-enabled
-                                        (memq mode '(java-mode conf-javaprop-mode yaml-mode))
+                                        (memq mode '(java-mode java-ts-mode conf-javaprop-mode yaml-mode))
                                         (lsp-java-boot--server-jar)))
                   :request-handlers  (ht ("sts/addClasspathListener" #'lsp-java-boot--sts-add-classpath-listener)
                                          ("sts/javadocHoverLink" #'lsp-java-boot--sts-javadoc-hover-link)

--- a/lsp-java.el
+++ b/lsp-java.el
@@ -786,10 +786,10 @@ PARAMS progress report notification data."
 (put 'lsp-java-progress-string 'risky-local-variable t)
 
 (defun lsp-java--render-string (str)
-  "Render STR with `java-mode' syntax highlight."
+  "Render STR with `java-mode and java-ts-mode' syntax highlight."
   (condition-case nil
       (with-temp-buffer
-        (delay-mode-hooks (java-mode))
+        (delay-mode-hooks (java-mode java-ts-mode))
         (insert str)
         (font-lock-ensure)
         (buffer-string))
@@ -1402,7 +1402,7 @@ current symbol."
  (make-lsp--client
   :new-connection (lsp-stdio-connection #'lsp-java--ls-command
                                         #'lsp-java--locate-server-jar)
-  :major-modes '(java-mode jdee-mode)
+  :major-modes '(java-mode java-ts-mode jdee-mode)
   :server-id 'jdtls
   :multi-root t
   :notification-handlers (ht ("language/status" #'lsp-java--language-status-callback)


### PR DESCRIPTION
Although updates were made to `lsp-mode` in [#3858](https://github.com/emacs-lsp/lsp-mode/pull/3858) there needs to be supporting changes in `lsp-java` as well.