### PR TITLE
Resolved problem with duplicate test class names in dap-java--run-unit-test-command

### DIFF
--- a/dap-java.el
+++ b/dap-java.el
@@ -255,10 +255,11 @@ surrounding method.  Otherwise it will run the surrounding test."
           (to-run (if run-method?
                       (dap-java-test-method-at-point)
                     (dap-java-test-class)))
+          (project-name (dap-java--extract-project-name))
           (test-class-name (cl-first (s-split "#" to-run)))
           (class-path (->> (with-lsp-workspace (lsp-find-workspace 'jdtls)
                              (lsp-send-execute-command "vscode.java.resolveClasspath"
-                                                       (vector test-class-name nil)))
+                                                       (vector test-class-name project-name)))
                            cl-second
                            (s-join dap-java--classpath-separator)))
           (prog-list (if dap-java-use-testng
@@ -278,6 +279,17 @@ surrounding method.  Otherwise it will run the surrounding test."
           :environment-variables `(("JUNIT_CLASS_PATH" . ,class-path))
           :name to-run
           :cwd (lsp-java--get-root))))
+
+(defun dap-java--extract-project-name ()
+  "Extract the project name from the .project FILE."
+  (let ((project-file (concat (lsp-java--get-root) ".project"))
+        (project-name nil))
+    (with-temp-buffer
+      (insert-file-contents project-file)
+      (goto-char (point-min))
+      (when (re-search-forward "<name>\\(.+?\\)</name>" nil t)
+        (setq project-name (match-string 1))))
+    project-name))
 
 (defun dap-java-run-test-method ()
   "Run JUnit test.


### PR DESCRIPTION
I had this problem:
I had test classes with the exact same names in different projects. The qualified class name was the same for both: com.something.TestClass

When trying to run the `dap-java-run-test-class`, the `vscode.java.resolveClasspath` command in the `dap-java--run-unit-test-command` function failed because it could not differentiate between the two. I got the error: `Failed to resolve classpath: X class 'X' isn't unique in the workspace, please pass in specified projectname.`

Therefore, I modified the dap-java--run-unit-test-command function to pass dynamically the project name to the `vscode.java.resolveClasspath` command as a second argument, in order for it to differentiate between the two duplicate test classes. 

The project name is extracted via a second function, which gets it from the .project file that resides at the root of the repo.
Feel free to rewrite this function, if you come up with a better way to get the project name.

The end result is that `dap-java-run-test-class` works, even if two test classes have the exact same names in different projects.
