### PR TITLE
make lsp-java-format-tab-size compatible with java-ts-mode

### DIFF
--- a/lsp-java.el
+++ b/lsp-java.el
@@ -385,9 +385,11 @@ example 'java.awt.*' will hide all types from the awt packages."
   :type '(lsp-repeatable-vector string)
   :lsp-path "java.completion.filteredTypes")
 
-(lsp-defcustom lsp-java-format-tab-size 'c-basic-offset
+(lsp-defcustom lsp-java-format-tab-size (lambda () (if (equal major-mode 'java-ts-mode)
+                                                       java-ts-mode-indent-offset
+                                                     c-basic-offset))
   "The basic offset"
-  :type 'symbol
+  :type 'function
   :lsp-path "java.format.tabSize")
 
 (lsp-defcustom lsp-java-format-insert-spaces (lambda () (not indent-tabs-mode))


### PR DESCRIPTION
fix #447, fix #451

Currently `lsp-java-format-tab-size` is `c-basic-offset`. By default c-basic-offset is a special value `set-from-style. When java-mode starts it will get set to a number such as 4 or 2.

java-ts-mode won't do anything with c-basic-offset. So lsp will fail to generate the initializationOptions json because tabSize is set-from-style.

This MR turns lsp-java-format-tab-size to a function to return correct indent setting depending whether java-ts-mode is on or not.

This is a fancy solution. A simple and fool proof one can be a number value

```elisp
(lsp-defcustom lsp-java-format-tab-size 4
  "The basic offset"
  :type 'number
  :lsp-path "java.format.tabSize")
```