### PR TITLE
Surround variable format with quotes for shell agnosticism

### DIFF
--- a/dap-java.el
+++ b/dap-java.el
@@ -38,7 +38,7 @@
 
 (defvar dap-java--var-format (if (string= system-type "windows-nt")
                                  "%%%s%%"
-                               "$%s"))
+                               "\"$%s\""))
 
 ;; Set to non-nil to use TestNG instead of the default JUnit
 (defvar dap-java-use-testng nil)


### PR DESCRIPTION
My default shell on my system is fish and so emacs was using fish to run the dap java commands for my tests. I spent a long time trying to configure stuff and it was a bit more complicated than I wanted it to be, so I ended up just surrounding the `$JUNIT_CLASS_PATH` with quotes which worked for my case in fish, bash, and zsh.

The changes I made in my local copy of lsp-java fixed the issues I was having. I think it's usually best practice to surround shell variables with quotes as well, so I hope this doesn't interfere with anything. I can't see off-hand how it would, but perhaps there's a case I'm missing.

Either way, it's up for review. Thank you for your time and consideration.

Also, I couldn't find a `CONTRIBUTING.(md/org)` and there were no docs about contributing on the site, so I hope me forking the repo and contributing that way is acceptable. 