### PR TITLE
Update download URL to latest Eclipse JDT version

### DIFF
--- a/lsp-java.el
+++ b/lsp-java.el
@@ -61,7 +61,7 @@ lsp's java -jar invocation."
   :risky t
   :type 'string)
 
-(defcustom lsp-java-jdt-download-url "https://www.eclipse.org/downloads/download.php?file=/jdtls/milestones/1.23.0/jdt-language-server-1.23.0-202304271346.tar.gz"
+(defcustom lsp-java-jdt-download-url "https://www.eclipse.org/downloads/download.php?file=/jdtls/milestones/1.48.0/jdt-language-server-1.48.0-202506271502.tar.gz"
   "JDT JS download url.
 Use https://download.eclipse.org/jdtls/milestones/1.12.0/jdt-language-server-1.12.0-202206011637.tar.gz if you want to use older java version."
   :type 'string)


### PR DESCRIPTION
I was lately using lsp-java with Java 24 and had to debug for quite a while because lsp-java downloads a version of the language server that is from 2023 by default.

This PR updates the download URL to the currently latest version of the language server, which should work better as default than the 2023 version.