### PR TITLE
Ignore missing JAR in native installations (allows installation of jdtls through NixOS)

### DIFF
--- a/lsp-java.el
+++ b/lsp-java.el
@@ -1401,7 +1401,10 @@ current symbol."
 (lsp-register-client
  (make-lsp--client
   :new-connection (lsp-stdio-connection #'lsp-java--ls-command
-                                        #'lsp-java--locate-server-jar)
+                                        (lambda ()
+                                          (or (and lsp-java-jdt-ls-prefer-native-command
+                                                   (lsp-java--locate-server-command))
+                                              (lsp-java--locate-server-jar))))
   :major-modes '(java-mode java-ts-mode jdee-mode)
   :server-id 'jdtls
   :multi-root t


### PR DESCRIPTION
Do not check for the existence of a JAR if a native command is preferred and there is a suitable executable.

I was hit by this issue on NixOS which puts the JAR at a different location than the auto detection of this package expects it. The alternative, setting `lsp-java-server-install-dir` such that the JAR instead of the executable is found, leads to a failure. When the JAR is launched directly, jdtls tries to write to the Nix Store which is read-only. Launching the jdtls executable provided by nixpkgs works perfectly though.

The error I encountered was exactly the same as described in #421. Hence, I believe this PR fixes that issue without overriding any private functions in the user configuration (see below).
As I understand it, this is also the alternative solution for #487 as suggested by @LuigiPiucco in https://github.com/emacs-lsp/lsp-java/issues/487#issuecomment-2383307915

In case this is desired, I could also add a default fallback in `lsp-java--locate-server-command` if `lsp-java-jdt-ls-prefer-native-command` is `t` and `lsp-java-jdt-ls-command` is found in `exec-path`.

## Working NixOS configuration
When installing `jdtls` globally, my working configuration after this PR looks like this:
```elisp
(setq lsp-java-jdt-ls-prefer-native-command t)
(setq lsp-java-server-install-dir (f-dirname (f-dirname (executable-find lsp-java-jdt-ls-command))))
```
Note that `jdt-language-server` was renamed to `jdtls` in nixpkgs. In case you are using some old nixpkgs version, you also need
```elisp
(setq lsp-java-jdt-ls-command "jdt-language-server")
```
before the first two lines.

If you want to use nix shells with direnv, you can follow the [guide by @dschrempf](https://dschrempf.github.io/emacs/2023-03-02-emacs-java-and-nix/) and use the following Emacs configuration:
```elisp
(defun my-set-lsp-path ()
  (let ((jdtls-exe (executable-find lsp-java-jdt-ls-command)))
    (when jdtls-exe
      (setq lsp-java-jdt-ls-prefer-native-command t)
      (setq lsp-java-server-install-dir (f-dirname (f-dirname jdtls-exe))))))
(after! cc-mode
  (add-hook 'java-mode-hook #'my-set-lsp-path))
```